### PR TITLE
bug fix: edit state

### DIFF
--- a/resources/js/modules/users/pages/ProfilePage.tsx
+++ b/resources/js/modules/users/pages/ProfilePage.tsx
@@ -78,6 +78,11 @@ export default function ProfilePage({}: ProfilePageProps) {
     }
   }, [activeTab]);
 
+  // Reset editing mode when switching tabs
+  useEffect(() => {
+    setIsEditing(false);
+  }, [activeTab]);
+
   const loadProfile = async () => {
     try {
       setIsLoading(true);


### PR DESCRIPTION
Fixed bug where edit state remains true even when switching between tabs in the profile page:
- added useEffect to setIsEditing->false when changing between profile tabs

closes #47 